### PR TITLE
Fixes by export

### DIFF
--- a/models/addressable.go
+++ b/models/addressable.go
@@ -27,6 +27,11 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
+const (
+	MethodGet  = "GET"
+	MethodPost = "POST"
+)
+
 /*
  * This file is the model for addressable in EdgeX
  * Addressable holds information about a specific address

--- a/models/reading.go
+++ b/models/reading.go
@@ -32,8 +32,8 @@ import (
  */
 type Reading struct {
 	Id       bson.ObjectId `bson:"_id,omitempty"`
-	Pushed   int64         `bson:"pushed" json:"pushed"`    // When the data was pushed out of EdgeX (0 - not pushed yet)
-	Created  int64         `bson: "created" json:"created"` // When the reading was created
+	Pushed   int64         `bson:"pushed" json:"pushed"`   // When the data was pushed out of EdgeX (0 - not pushed yet)
+	Created  int64         `bson:"created" json:"created"` // When the reading was created
 	Origin   int64         `bson:"origin" json:"origin"`
 	Modified int64         `bson:"modified" json:"modified"`
 	Device   string        `bson:"device" json:"device"`


### PR DESCRIPTION
Some fixes needed by export services to be able to use core-domain-go instead of duplicating the types.